### PR TITLE
Refactor `fetch.py` and `main.py`.

### DIFF
--- a/fetch.py
+++ b/fetch.py
@@ -1,102 +1,54 @@
 """ Fetching arXiv papers from public API. """
 
+import itertools
 import urllib.request as libreq
-from datetime import date, timedelta
-from typing import List
+from typing import List, Tuple
+from datetime import date
+from functools import reduce
 
 import feedparser
 
 from paper import Paper
 
-
+# Construct API query.
 CATEGORY = "cs.LG"
 PAGE_RESULTS = 100
+QUERY = "http://export.arxiv.org/api/query?"
+QUERY += f"search_query=cat:{CATEGORY}"
+QUERY += "&sortBy=submittedDate&sortOrder=descending"
+QUERY += "&start={}"
+QUERY += f"&max_results={PAGE_RESULTS}"
 
 
-def get_papers(init_date=None, checkpoint=None) -> List[Paper]:
-    """
-    Get a list of arXiv papers released on or after the later of ``init_date`` and
-    ``checkpoint`` minus 14 days. ``checkpoint`` is the last date that the user "caught
-    up" and rated all papers which were currently available at the time of rating. This
-    is a bit janky, but it's the cleanest way I've thought of to deal with the fact that
-    the arXiv API only dates papers by when they were submitted, but not all papers
-    which are submitted on the same day are released on the same day. The 14 day cushion
-    accounts for the event where we rate papers which were submitted on a given day, and
-    sometime after there are other papers released which were submitted on that same
-    day.
-    """
-
-    # Construct API query.
-    query_template = "http://export.arxiv.org/api/query?"
-    query_template += f"search_query=cat:{CATEGORY}"
-    query_template += "&sortBy=submittedDate&sortOrder=descending"
-    query_template += "&start={start}"
-    query_template += f"&max_results={PAGE_RESULTS}"
-
-    # Construct start date for papers.
-    if checkpoint is None and init_date is None:
-        start_date = None
-    elif checkpoint is None and init_date is not None:
-        start_date = init_date
-    elif checkpoint is not None and init_date is not None:
-        start_date = max(init_date, checkpoint - timedelta(days=14))
-    else:
-        raise NotImplementedError
-
-    # Query API in pages until we get all papers from the desired range.
+def get_papers(start: date) -> List[Paper]:
+    """Download and parse papers since ``start``."""
+    pages = itertools.count(start=0, step=PAGE_RESULTS)
+    queries = map(QUERY.format, pages)
+    responses = map(lambda q: libreq.urlopen(q).read(), queries)
+    batches = map(parse_response, responses)
     papers = []
-    start = 0
-    finished = False
-    while not finished:
-        query = query_template.format(start=start)
-        with libreq.urlopen(query) as url:
-            response = url.read()
-
-        # Parse API response.
-        batch_papers = parse_response(response)
-        if len(batch_papers) == 0:
-            finished = True
-
-        # Check if we have gotten all papers from the desired range.
-        for paper in batch_papers:
-
-            # Set start date to date of most recent paper, if necessary.
-            if start_date is None:
-                start_date = paper.published
-                init_date = start_date
-
-            if paper.published >= start_date:
-                papers.append(paper)
-            else:
-                finished = True
-                break
-
-        start += PAGE_RESULTS
-
-    return papers, init_date
+    for batch in batches:
+        batch = list(filter(lambda p: p.published >= start, batch))
+        papers = reduce(lambda acc, p: acc + [p], batch, papers)
+        if len(batch) == 0:
+            break
+    return papers
 
 
 def parse_response(response: bytes) -> List[Paper]:
-    """ Parse an Atom response from the arXiv API into a list of papers. """
-
-    feed = feedparser.parse(response.decode())
+    """Parse an Atom response from the arXiv API into a list of papers."""
     papers = []
-    for entry in feed.entries:
+    for entry in feedparser.parse(response.decode()).entries:
         abs_pos = entry.id.find("abs/")
-        bare_id = entry.id[abs_pos+4:]
-        first_dash = entry.updated.find("-")
-        second_dash = entry.updated.find("-", first_dash + 1)
-        T_pos = entry.updated.find("T")
-        year = int(entry.updated[:first_dash])
-        month = int(entry.updated[first_dash + 1: second_dash])
-        day = int(entry.updated[second_dash + 1: T_pos])
-        papers.append(Paper(
-            identifier=bare_id,
-            title=entry.title,
-            authors=[a["name"] for a in entry.authors],
-            published=date(year, month, day),
-            abstract=entry.summary,
-            link=entry.link,
-        ))
-
+        bare_id = entry.id[abs_pos + 4 :]
+        papers.append(
+            Paper(
+                identifier=bare_id,
+                title=entry.title,
+                authors=[a["name"] for a in entry.authors],
+                published=date(*entry.published_parsed[:3]),
+                abstract=entry.summary,
+                link=entry.link,
+            )
+        )
     return papers

--- a/interface.py
+++ b/interface.py
@@ -1,21 +1,21 @@
 """ Text-based interface. """
 
 from datetime import date
-from typing import Tuple, List
+from typing import List
 
 import numpy as np
 
 from paper import Paper
 
 
-LINE_LEN = 88
+WIDTH = 88
+SEPARATOR = f"\n{'=' * WIDTH}\n"
 VALID_RATINGS = ["-1", "0", "1", "2"]
 
 
 def get_ratings(
-    papers: List,
+    papers: List[Paper],
     pred_ratings: np.ndarray,
-    batch_size: int,
     init_date: date,
     checkpoint: date,
 ) -> dict:
@@ -23,11 +23,11 @@ def get_ratings(
 
     ratings = {}
 
-    print("\n" + "=" * LINE_LEN + "\n")
+    print(SEPARATOR)
     print(f"Initial date: {init_date}")
     print(f"Last checkpoint: {checkpoint}")
     print(f"Today's date: {date.today()}")
-    print(f"Collected {batch_size} papers since checkpoint.")
+    print(f"Collected {len(papers)} papers since checkpoint.")
 
     finished = False
     for i, paper in enumerate(papers):
@@ -38,7 +38,7 @@ def get_ratings(
             continue
 
         try:
-            prefix = f"[{i+1}/{batch_size}]"
+            prefix = f"[{i+1}/{len(papers)}]"
             rating = get_rating(paper, prefix, pred_ratings[i])
 
             # Check for -1 rating. This will give a 0 to the current paper and the rest
@@ -52,7 +52,7 @@ def get_ratings(
             print("\n\nSaving partial results.\n")
             break
 
-    print("\n" + "=" * LINE_LEN + "\n")
+    print(SEPARATOR)
     return ratings
 
 
@@ -60,17 +60,8 @@ def get_rating(paper: Paper, prefix: str, pred_rating: float) -> bool:
     """ Print information for a paper and collect/return user rating. """
 
     # Print paper information.
-    print("\n" + "=" * LINE_LEN + "\n")
-    print(prefix + " " + paper.title)
-    print(paper.published)
-    print(paper.link)
-    print("")
-    if len(paper.authors) > 0:
-        print(paper.authors[0], end="")
-        for author in paper.authors[1:]:
-            print(f", {author}", end="")
-        print("\n")
-    print(paper.abstract)
+    print(SEPARATOR)
+    print(f"{prefix} {paper}")
 
     # Get user rating.
     rating = None

--- a/main.py
+++ b/main.py
@@ -2,6 +2,11 @@
 
 import os
 import pickle
+from typing import Dict, Union
+from dataclasses import dataclass
+
+import datetime
+from datetime import timedelta
 
 from fetch import get_papers
 from interface import get_ratings
@@ -9,45 +14,59 @@ from recommender import recommended_sort, train_recommender
 from utils import USER_DATA_PATH
 
 
+@dataclass(frozen=True, eq=True)
+class Save:
+    ratings: Dict[str, float]
+    date: Union[datetime.date, None]
+    init: datetime.date
+
+
 def main():
+    """
+    Get a list of arXiv papers released on or after the later of ``init`` and
+    ``save.date`` minus 14 days.
+
+    Note that ``save.date`` is the last date that the user "caught up" and
+    rated all papers which were currently available at the time of rating. This
+    is a bit janky, but it's the cleanest way I've thought of to deal with the
+    fact that the arXiv API only dates papers by when they were submitted, but
+    not all papers which are submitted on the same day are released on the same
+    day.
+
+    The 14 day cushion accounts for the event where we rate papers which were
+    submitted on a given day, and sometime after there are other papers
+    released which were submitted on that same day.
+    """
 
     # Read database of ratings.
+    save = Save(ratings={}, date=None, init=datetime.date.today() - timedelta(days=3))
     if os.path.isfile(USER_DATA_PATH):
         with open(USER_DATA_PATH, "rb") as f:
-            user_data = pickle.load(f)
-        ratings = user_data["ratings"]
-        checkpoint = user_data["checkpoint"]
-        init_date = user_data["init_date"]
-    else:
-        ratings = {}
-        checkpoint = None
-        init_date = None
+            save = pickle.load(f)
+    init = save.init
 
-    # Fetch arXiv releases since checkpoint and keep those that haven't yet been rated.
-    batch_papers, init_date = get_papers(init_date=init_date, checkpoint=checkpoint)
-    unrated_papers = [p for p in batch_papers if p.identifier not in ratings.keys()]
+    # Construct start date for papers.
+    start = init if save.date is None else max(init, save.date - timedelta(days=14))
+
+    # Fetch arXiv releases since ``save.date`` and keep those that haven't been rated.
+    papers = get_papers(start)
+    unrated_papers = [p for p in papers if p.identifier not in save.ratings.keys()]
 
     # Sort unrated papers by predicted rating and present to user for rating.
     unrated_papers, pred_ratings = recommended_sort(unrated_papers)
-    batch_ratings = get_ratings(
-        unrated_papers, pred_ratings, len(unrated_papers), init_date, checkpoint
-    )
-    finished = (len(batch_ratings) == len(unrated_papers))
+    batch_ratings = get_ratings(unrated_papers, pred_ratings, init, save.date)
+    finished = len(batch_ratings) == len(unrated_papers)
 
     # Update database of ratings.
-    ratings.update(batch_ratings)
-    parent = os.path.dirname(USER_DATA_PATH)
-    if not os.path.isdir(parent):
-        os.makedirs(parent)
+    ratings = {**save.ratings, **batch_ratings}
+    latest = init
+    if len(ratings) > 0 and finished:
+        latest = max(p.published for p, _ in ratings.values())
+
+    # Serialize checkpoint.
+    os.makedirs(os.path.dirname(USER_DATA_PATH), exist_ok=True)
     with open(USER_DATA_PATH, "wb") as f:
-        if len(ratings) > 0 and finished:
-            checkpoint = max([p.published for (p, _) in ratings.values()])
-        user_data = {
-            "ratings": ratings,
-            "checkpoint": checkpoint,
-            "init_date": init_date
-        }
-        pickle.dump(user_data, f)
+        pickle.dump(Save(ratings=ratings, date=latest, init=init), f)
 
     # Retrain SVM with new ratings.
     if len(ratings) > 0:

--- a/paper.py
+++ b/paper.py
@@ -5,7 +5,6 @@ from typing import List
 
 
 class Paper:
-
     def __init__(
         self,
         identifier: str,
@@ -23,11 +22,13 @@ class Paper:
         self.link = str(link)
 
     def __repr__(self):
-        msg = ""
-        msg += f"ID: {self.identifier}\n"
-        msg += f"Title: {self.title}\n"
-        msg += f"Authors: {self.authors}\n"
-        msg += f"Published: {self.published}\n"
-        msg += f"Abstract: {self.abstract}\n"
-        msg += f"Link: {self.link}\n"
-        return msg
+        return "\n".join(
+            [
+                self.title,
+                str(self.published),
+                self.link,
+                "",
+                ", ".join(self.authors),
+                self.abstract,
+            ]
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 feedparser
-sklearn
+scikit-learn
+numpy


### PR DESCRIPTION
This commit simplifies the logic in `get_papers()`, `parse_response()`, and `main()`. We use lazy iteration instead of loops to cut down on boilerplate and to make things slightly faster.

The publication date is used everywhere instead of a mix of the last updated date and publication date, under the assumption that papers don't change enough to warrant re-rating after initial publication.

We move the query construction into the top-level to separate it from the downloading logic, and we move the start date determination into `main()` from `get_papers()`. The `init` date is now defaulted to 3 days ago in the absence of a checkpoint/save.

* Fix missing stuff and typo in `requirements.txt`.
* Rewrite `Paper.__repr__()` and use it in `interface.py`.
* Drop `batch_size` argument as it is unnecessary for the moment.
* Add an immutable `Save` dataclass to reduce boilerplate in the checkpointing procedure.